### PR TITLE
Update Client::withApiKey to a public static method

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -2,7 +2,7 @@
 namespace TaxJar;
 
 class Client extends TaxJar {
-  public function withApiKey($key) {
+  public static function withApiKey($key) {
     return new Client($key);
   }
 


### PR DESCRIPTION
The documentation specifies that TaxJar client should be instantiated statically, so the withApiKey method should be a public static function. 
