### PR TITLE
Parameters in GET request need to be escaped

### DIFF
--- a/lib/Util/Request.php
+++ b/lib/Util/Request.php
@@ -43,7 +43,7 @@ class Request {
       default:
         $options[CURLOPT_CUSTOMREQUEST] = $method;
         if ($parameters) {
-          $url .= '/?' . $parameters;
+          $url .= '/?' . urlencode($parameters);
         }
         break;
     }


### PR DESCRIPTION
Parameters should be passed through urlencode so that any invalid characters are escaped (ie: spaces). Otherwise, taxjar will return "HTTP/1.1 505 HTTP Version Not Supported". 

You can test this by calling the example in the README.md:

$rates = $taxjar->ratesForLocation(90002, [
  'city' => 'LOS ANGELES',
  'country' => 'US'
]);

Since "LOS ANGELES" has a space, it will throw the error 
