### PR TITLE
Relax GuzzleHttp Version Specificity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   ],
   "require": {
     "php": ">=5.5.0",
-    "guzzlehttp/guzzle": "6.0.2"
+    "guzzlehttp/guzzle": "^6.0.2"
   },
   "require-dev": {
     "phpunit/phpunit": "4.8.*",


### PR DESCRIPTION
Tests appeared to pass for me, this relaxing of guzzle version should always be non-breaking. https://getcomposer.org/doc/articles/versions.md#caret
