### PR TITLE
Improved Exception Handling

### DIFF
--- a/lib/Exception.php
+++ b/lib/Exception.php
@@ -2,5 +2,14 @@
 namespace TaxJar;
 
 class Exception extends \Exception {
+    protected $status_code;
 
+    public function __construct($message, $status_code = 0) {
+        $this->status_code = $status_code;
+        parent::__construct($message);
+    }
+
+    final public function getStatusCode() {
+        return $this->status_code;
+    }
 }

--- a/lib/TaxJar.php
+++ b/lib/TaxJar.php
@@ -25,7 +25,7 @@ class TaxJar {
     $handler->push(\GuzzleHttp\Middleware::mapResponse(function($response) {
       if ($response->getStatusCode() >= 400) {
         $data = json_decode($response->getBody());
-        throw new Exception(sprintf('%s %s – %s', $response->getStatusCode(), $data->error, $data->detail));
+        throw new Exception(sprintf('%s %s – %s', $response->getStatusCode(), $data->error, $data->detail), $response->getStatusCode());
       }
       
       return $response;

--- a/test/specs/TokenTest.php
+++ b/test/specs/TokenTest.php
@@ -9,6 +9,55 @@ class TokenTest extends TaxJarTest {
       $this->client = TaxJar\Client::withApiKey(null);
     } catch(Exception $e) {
       $this->assertEquals($e->getMessage(), 'Please provide an API key.');
+      $this->assertEquals($e->getStatusCode(), 0);
+    }
+  }
+
+  public function test_unauthorized_token_exception() {
+    try {
+      $this->http->mock
+          ->when()
+              ->methodIs('GET')
+              ->pathIs('/categories')
+          ->then()
+              ->statusCode(401)
+              ->body(json_encode([
+                'error' => "Unauthorized",
+                'detail' => "Not authorized for route 'GET /v2/categories'",
+                'status' => 401
+              ]))
+          ->end();
+
+      $this->http->setUp();
+
+      $response = $this->client->categories();
+    } catch(Exception $e) {
+      $this->assertEquals($e->getMessage(), "401 Unauthorized – Not authorized for route 'GET /v2/categories'");
+      $this->assertEquals($e->getStatusCode(), 401);
+    }
+  }
+
+  public function test_expired_token_exception() {
+    try {
+      $this->http->mock
+          ->when()
+              ->methodIs('GET')
+              ->pathIs('/categories')
+          ->then()
+              ->statusCode(403)
+              ->body(json_encode([
+                'error' => "Forbidden",
+                'detail' => "Not authorized for resource",
+                'status' => 403
+              ]))
+          ->end();
+
+      $this->http->setUp();
+
+      $response = $this->client->categories();
+    } catch(Exception $e) {
+      $this->assertEquals($e->getMessage(), "403 Forbidden – Not authorized for resource");
+      $this->assertEquals($e->getStatusCode(), 403);
     }
   }
 }


### PR DESCRIPTION
This PR addresses #14 and passes the error status code separately for improved exception handling. This way a developer can catch an exception and use a switch to look at the status code with the new `getStatusCode` exception method instead of parsing the message string.

For backward compatibility, the original message string was left intact and the status code was added as a new argument.