### PR TITLE
Address Validation

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -301,6 +301,22 @@ class Client extends TaxJar
     }
 
     /**
+     * Validate an address
+     * https://developers.taxjar.com/api/reference/?php#post-validate-an-address
+     *
+     * @param array $parameters
+     *
+     * @return object Validation object.
+     */
+    public function validateAddress($parameters = [])
+    {
+        $response = $this->client->post('addresses/validate', [
+            'json' => $parameters,
+        ]);
+        return json_decode($response->getBody())->addresses;
+    }
+
+    /**
      * Validate a VAT number
      * https://developers.taxjar.com/api/reference/?php#get-validate-a-vat-number
      *

--- a/test/fixtures/addresses.json
+++ b/test/fixtures/addresses.json
@@ -1,0 +1,11 @@
+{
+    "addresses": [
+        {
+            "zip": "85297-2176",
+            "street": "3301 S Greenfield Rd",
+            "state": "AZ",
+            "country": "US",
+            "city": "Gilbert"
+        }
+    ]
+}

--- a/test/specs/ValidationTest.php
+++ b/test/specs/ValidationTest.php
@@ -5,6 +5,32 @@ if (!class_exists('TaxJarTest')) {
 
 class ValidationTest extends TaxJarTest
 {
+    public function testValidateAddress()
+    {
+        $this->http->mock
+            ->when()
+            ->methodIs('POST')
+            ->pathIs('/addresses/validate')
+            ->then()
+            ->statusCode(200)
+            ->body(file_get_contents(__DIR__ . "/../fixtures/addresses.json"))
+            ->end();
+
+        $this->http->setUp();
+
+        $response = $this->client->validateAddress([
+            'country' => 'US',
+            'state' => 'AZ',
+            'zip' => '85297',
+            'city' => 'Gilbert',
+            'street' => '3301 South Greenfield Rd'
+        ]);
+
+        $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/addresses.json', json_encode([
+            "addresses" => $response
+        ]));
+    }
+
     public function testValidation()
     {
         $this->http->mock


### PR DESCRIPTION
This PR adds support for TaxJar's address validation beta endpoint via `validateAddress`. At this time, address validation is only available for TaxJar Plus customers.