### PR TITLE
Reduced redundant code.

### DIFF
--- a/lib/Exception.php
+++ b/lib/Exception.php
@@ -3,16 +3,11 @@ namespace TaxJar;
 
 class Exception extends \Exception
 {
-    protected $status_code;
-
-    public function __construct($message, $status_code = 0)
-    {
-        $this->status_code = $status_code;
-        parent::__construct($message);
-    }
-
+    /**
+     * Alias to getCode, for backwards compatibility
+     */
     final public function getStatusCode()
     {
-        return $this->status_code;
+        return $this->getCode();
     }
 }


### PR DESCRIPTION
[php.net\Exception](http://php.net/manual/en/class.exception.php) has an exception code as the 2nd constructor argument.

TaxJar\Exception adds an exception code, blocking usage of the php's error code as the 2nd constructor argument.

There doesn't appear to be a reason for the additional exception code, while blocking the built in exception code.

This allows for integration tests with TaxJar client to use PHPUnit's `$this->expectExceptionCode` and likely other frameworks that expect exceptions to use exception's built in features, rather than implementations of identical features.

Given that there was an intentional addition of this though, it is possible I'm overlooking the purpose of the override added in https://github.com/taxjar/taxjar-php/pull/15