### PR TITLE
Accept params passed to showOrder, deleteOrder, showRefund, deleteRefund

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -79,12 +79,15 @@ class Client extends TaxJar
      * https://developers.taxjar.com/api/?php#show-an-order-transaction
      *
      * @param integer $transaction_id
+     * @param array $parameters
      *
      * @return object Order object.
      */
-    public function showOrder($transaction_id)
+    public function showOrder($transaction_id, $parameters = [])
     {
-        $response = $this->client->get('transactions/orders/' . $transaction_id);
+        $response = $this->client->get('transactions/orders/' . $transaction_id, [
+            'query' => $parameters,
+        ]);
         return json_decode($response->getBody())->order;
     }
 
@@ -126,12 +129,15 @@ class Client extends TaxJar
      * https://developers.taxjar.com/api/?php#delete-an-order-transaction
      *
      * @param integer $transaction_id
+     * @param array $parameters
      *
      * @return object Order object.
      */
-    public function deleteOrder($transaction_id)
+    public function deleteOrder($transaction_id, $parameters = [])
     {
-        $response = $this->client->delete('transactions/orders/' . $transaction_id);
+        $response = $this->client->delete('transactions/orders/' . $transaction_id, [
+            'query' => $parameters,
+        ]);
         return json_decode($response->getBody())->order;
     }
 
@@ -156,12 +162,15 @@ class Client extends TaxJar
      * https://developers.taxjar.com/api/?php#show-a-refund-transaction
      *
      * @param integer $transaction_id
+     * @param array $parameters
      *
      * @return object Refund object.
      */
-    public function showRefund($transaction_id)
+    public function showRefund($transaction_id, $parameters = [])
     {
-        $response = $this->client->get('transactions/refunds/' . $transaction_id);
+        $response = $this->client->get('transactions/refunds/' . $transaction_id, [
+            'query' => $parameters,
+        ]);
         return json_decode($response->getBody())->refund;
     }
 
@@ -202,12 +211,15 @@ class Client extends TaxJar
      * https://developers.taxjar.com/api/?php#delete-a-refund-transaction
      *
      * @param integer $transaction_id
+     * @param array $parameters
      *
      * @return object Refund object.
      */
-    public function deleteRefund($transaction_id)
+    public function deleteRefund($transaction_id, $parameters = [])
     {
-        $response = $this->client->delete('transactions/refunds/' . $transaction_id);
+        $response = $this->client->delete('transactions/refunds/' . $transaction_id, [
+            'query' => $parameters,
+        ]);
         return json_decode($response->getBody())->refund;
     }
 

--- a/test/fixtures/orders/show.json
+++ b/test/fixtures/orders/show.json
@@ -2,6 +2,7 @@
   "order": {
     "transaction_id": "123",
     "user_id": 10649,
+    "provider": "api",
     "transaction_date": "2015-05-14T00:00:00Z",
     "to_country": "US",
     "to_zip": "90002",

--- a/test/fixtures/refunds/show.json
+++ b/test/fixtures/refunds/show.json
@@ -2,6 +2,7 @@
   "refund": {
     "transaction_id": "321",
     "user_id": 10649,
+    "provider": "api",
     "transaction_date": "2015-05-14T00:00:00Z",
     "transaction_reference_id": "123",
     "to_country": "US",

--- a/test/specs/TransactionTest.php
+++ b/test/specs/TransactionTest.php
@@ -48,6 +48,28 @@ class TransactionTest extends TaxJarTest
         ]));
     }
 
+    public function testShowOrderWithParams()
+    {
+        $this->http->mock
+            ->when()
+            ->methodIs('GET')
+            ->pathIs('/transactions/orders/123?provider=api')
+            ->then()
+            ->statusCode(200)
+            ->body(file_get_contents(__DIR__ . "/../fixtures/orders/show.json"))
+            ->end();
+
+        $this->http->setUp();
+
+        $response = $this->client->showOrder(123, [
+            'provider' => 'api',
+        ]);
+
+        $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/orders/show.json', json_encode([
+            "order" => $response
+        ]));
+    }
+
     public function testCreateOrder()
     {
         $this->http->mock
@@ -142,6 +164,28 @@ class TransactionTest extends TaxJarTest
         ]));
     }
 
+    public function testDeleteOrderWithParams()
+    {
+        $this->http->mock
+            ->when()
+            ->methodIs('DELETE')
+            ->pathIs('/transactions/orders/123?provider=api')
+            ->then()
+            ->statusCode(200)
+            ->body(file_get_contents(__DIR__ . "/../fixtures/orders/show.json"))
+            ->end();
+
+        $this->http->setUp();
+
+        $response = $this->client->deleteOrder(123, [
+            'provider' => 'api',
+        ]);
+
+        $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/orders/show.json', json_encode([
+            "order" => $response
+        ]));
+    }
+
     public function testListRefunds()
     {
         $this->http->mock
@@ -179,6 +223,28 @@ class TransactionTest extends TaxJarTest
         $this->http->setUp();
 
         $response = $this->client->showRefund(321);
+
+        $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/refunds/show.json', json_encode([
+            "refund" => $response
+        ]));
+    }
+
+    public function testShowRefundWithParams()
+    {
+        $this->http->mock
+            ->when()
+            ->methodIs('GET')
+            ->pathIs('/transactions/refunds/321?provider=api')
+            ->then()
+            ->statusCode(200)
+            ->body(file_get_contents(__DIR__ . "/../fixtures/refunds/show.json"))
+            ->end();
+
+        $this->http->setUp();
+
+        $response = $this->client->showRefund(321, [
+            'provider' => 'api',
+        ]);
 
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/refunds/show.json', json_encode([
             "refund" => $response
@@ -273,6 +339,28 @@ class TransactionTest extends TaxJarTest
         $this->http->setUp();
 
         $response = $this->client->deleteRefund(321);
+
+        $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/refunds/show.json', json_encode([
+            "refund" => $response
+        ]));
+    }
+
+    public function testDeleteRefundWithParams()
+    {
+        $this->http->mock
+            ->when()
+            ->methodIs('DELETE')
+            ->pathIs('/transactions/refunds/321?provider=api')
+            ->then()
+            ->statusCode(200)
+            ->body(file_get_contents(__DIR__ . "/../fixtures/refunds/show.json"))
+            ->end();
+
+        $this->http->setUp();
+
+        $response = $this->client->deleteRefund(321, [
+            'provider' => 'api',
+        ]);
 
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/refunds/show.json', json_encode([
             "refund" => $response


### PR DESCRIPTION
This change adds a second parameter (`$parameters`) to each of the following methods:

- `showOrder`
- `deleteOrder`
- `showRefund`
- `deleteRefund`

Using `$parameters`, you can now pass additional parameters to each of the methods such as `provider`:

```php
$response = $this->client->showRefund(321, [
    'provider' => 'api',
]);
```