### PR TITLE
Update .travis.yml to test with php 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
 language: php
 
+dist: trusty
+
 php:
   - '5.5'
   - '5.6'
   - '7.0'
   - '7.1'
   - '7.2'
-  
+
 before_script:
   - composer self-update
   - composer install
-  
+
 script: php vendor/bin/phpunit test/specs/.


### PR DESCRIPTION
PHP 5.5 is not available in Travis CI's default `xenial`. Switching to `trusty` allows us to test in v5.5. See [here](https://travis-ci.community/t/php-5-4-and-5-5-archives-missing/3723) for more.