### PR TITLE
Add a custom user agent string to each request

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "taxjar/taxjar-php",
   "description": "Sales Tax API Client for PHP 5.5+",
+  "version": "1.9.0",
   "keywords": [
     "taxjar",
     "sales tax",

--- a/lib/TaxJar.php
+++ b/lib/TaxJar.php
@@ -18,7 +18,8 @@ class TaxJar
                 'handler' => $this->errorHandler(),
                 'headers' => [
                     'Authorization' => 'Bearer ' . $key,
-                    'Content-Type' => 'application/json'
+                    'Content-Type' => 'application/json',
+                    'User-Agent' => $this->getUserAgent()
                 ],
             ];
             $this->client = new \GuzzleHttp\Client($this->config);
@@ -76,5 +77,20 @@ class TaxJar
         } else {
             return $this->config;
         }
+    }
+
+    private function getUserAgent()
+    {
+        $os = function_exists('php_uname') ? php_uname('a') : '';
+        $php = 'PHP ' . PHP_VERSION;
+        $curl = function_exists('curl_version') ? 'cURL ' . curl_version()['version'] : '';
+        $openSSL = defined('OPENSSL_VERSION_TEXT') ? OPENSSL_VERSION_TEXT : '';
+        try {
+            $version = json_decode(file_get_contents('composer.json', true))->version;
+        } catch (\Exception $e) {
+            $version = '';
+        }
+
+        return "TaxJar/PHP ($os; $php; $curl; $openSSL) taxjar-php/$version";
     }
 }

--- a/test/specs/ConfigTest.php
+++ b/test/specs/ConfigTest.php
@@ -29,10 +29,11 @@ class ConfigTest extends TaxJarTest
 
     public function testGetCustomHeaders()
     {
-        $this->assertEquals($this->client->getApiConfig('headers'), [
-            'Authorization' => 'Bearer test',
-            'Content-Type' => 'application/json'
-        ]);
+        $headers = $this->client->getApiConfig('headers');
+
+        $this->assertEquals($headers['Authorization'], 'Bearer test');
+        $this->assertEquals($headers['Content-Type'], 'application/json');
+        $this->assertRegExp('/TaxJar\/PHP \(.*\) taxjar-php\/\d+\.\d+\.\d+/', $headers['User-Agent']);
     }
 
     public function testSetCustomHeaders()
@@ -40,10 +41,12 @@ class ConfigTest extends TaxJarTest
         $this->client->setApiConfig('headers', [
             'X-TJ-Expected-Response' => 422
         ]);
-        $this->assertEquals($this->client->getApiConfig('headers'), [
-            'Authorization' => 'Bearer test',
-            'Content-Type' => 'application/json',
-            'X-TJ-Expected-Response' => 422
-        ]);
+
+        $headers = $this->client->getApiConfig('headers');
+
+        $this->assertEquals($headers['Authorization'], 'Bearer test');
+        $this->assertEquals($headers['Content-Type'], 'application/json');
+        $this->assertEquals($headers['X-TJ-Expected-Response'], 422);
+        $this->assertRegExp('/TaxJar\/PHP \(.*\) taxjar-php\/\d+\.\d+\.\d+/', $headers['User-Agent']);
     }
 }


### PR DESCRIPTION
To help debug technical issues, it's necessary to collect additional information about a user's server.

For that purpose, this PR adds a custom user agent string to each request, which includes the following information:

- Operating system
- PHP version
- cURL version
- OpenSSL version
- Version of taxjar-php currently being used