### PR TITLE
Fix taxjar-php version in user agent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
   "name": "taxjar/taxjar-php",
   "description": "Sales Tax API Client for PHP 5.5+",
-  "version": "1.10.0",
   "keywords": [
     "taxjar",
     "sales tax",

--- a/lib/TaxJar.php
+++ b/lib/TaxJar.php
@@ -3,6 +3,7 @@ namespace TaxJar;
 
 class TaxJar
 {
+    const VERSION = '1.10.0';
     const DEFAULT_API_URL = 'https://api.taxjar.com';
     const SANDBOX_API_URL = 'https://api.sandbox.taxjar.com';
     const API_VERSION = 'v2';
@@ -85,12 +86,7 @@ class TaxJar
         $php = 'PHP ' . PHP_VERSION;
         $curl = function_exists('curl_version') ? 'cURL ' . curl_version()['version'] : '';
         $openSSL = defined('OPENSSL_VERSION_TEXT') ? OPENSSL_VERSION_TEXT : '';
-        try {
-            $version = json_decode(file_get_contents('composer.json', true))->version;
-        } catch (\Exception $e) {
-            $version = '';
-        }
 
-        return "TaxJar/PHP ($os; $php; $curl; $openSSL) taxjar-php/$version";
+        return "TaxJar/PHP ($os; $php; $curl; $openSSL) taxjar-php/" . self::VERSION;
     }
 }


### PR DESCRIPTION
In #30, a custom user agent was added to each request for debugging and informational purposes. Part of the user agent includes the taxjar-php version, for example: `taxjar-php/1.10.0`, which was being read from the package's `composer.json` file. 

When installing the package as a dependency, however, the incorrect `composer.json` file was being referenced and the version was either blank (`taxjar-php/`) or incorrect (displaying the installing project's `composer.json` version instead of taxjar-php's).

This PR fixes the issue by adding a `VERSION` constant, which must be updated with each release to display correctly in the user agent.