### PR TITLE
Format exception only when structure allows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.10.2] - 2020-06-02
+- Fix issue where some error messages were masked by improper formatting
+
 ## [1.10.1] - 2020-04-02
 - Fix issue with displaying current taxjar-php version in user agent
 
@@ -100,7 +103,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Initial release.
 
-[Unreleased]: https://github.com/taxjar/taxjar-php/compare/v1.10.1...HEAD
+[Unreleased]: https://github.com/taxjar/taxjar-php/compare/v1.10.2...HEAD
+[1.10.2]: https://github.com/taxjar/taxjar-php/compare/v1.10.1...v1.10.2
 [1.10.1]: https://github.com/taxjar/taxjar-php/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/taxjar/taxjar-php/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/taxjar/taxjar-php/compare/v1.8.1...v1.9.0

--- a/lib/TaxJar.php
+++ b/lib/TaxJar.php
@@ -35,10 +35,20 @@ class TaxJar
         $handler->push(\GuzzleHttp\Middleware::mapResponse(function ($response) {
             if ($response->getStatusCode() >= 400) {
                 $data = json_decode($response->getBody());
-                throw new Exception(
-                    sprintf('%s %s – %s', $response->getStatusCode(), $data->error, $data->detail),
-                    $response->getStatusCode()
-                );
+
+                if ($data && $data->error && $data->detail) {
+                    throw new Exception(
+                        sprintf(
+                            '%s %s – %s',
+                            $response->getStatusCode(),
+                            $data->error,
+                            $data->detail
+                        ),
+                        $response->getStatusCode()
+                    );
+                }
+
+                throw new Exception($response);
             }
 
             return $response;

--- a/lib/TaxJar.php
+++ b/lib/TaxJar.php
@@ -3,7 +3,7 @@ namespace TaxJar;
 
 class TaxJar
 {
-    const VERSION = '1.10.1';
+    const VERSION = '1.10.2';
     const DEFAULT_API_URL = 'https://api.taxjar.com';
     const SANDBOX_API_URL = 'https://api.sandbox.taxjar.com';
     const API_VERSION = 'v2';


### PR DESCRIPTION
This PR fixes an issue where errors not directly related to the TaxJar API (GuzzleHttp exceptions, for example) were sometimes being improperly formatted to the way we display TaxJar-related errors, causing unhelpful error messages to be displayed.

For example, a customer received an error without any pertinent details: `message : Trying to get property 'error' of non-object`

After release, general exceptions will be passed along to the consumer with no change in the original structure to avoid these unhelpful errors.