### PR TITLE
Tweak error handling changes from previous release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.10.3] - 2020-06-03
+- Tweak error handling and provide default error messages
+
 ## [1.10.2] - 2020-06-02
 - Fix issue where some error messages were masked by improper formatting
 
@@ -103,7 +106,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Initial release.
 
-[Unreleased]: https://github.com/taxjar/taxjar-php/compare/v1.10.2...HEAD
+[Unreleased]: https://github.com/taxjar/taxjar-php/compare/v1.10.3...HEAD
+[1.10.3]: https://github.com/taxjar/taxjar-php/compare/v1.10.2...v1.10.3
 [1.10.2]: https://github.com/taxjar/taxjar-php/compare/v1.10.1...v1.10.2
 [1.10.1]: https://github.com/taxjar/taxjar-php/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/taxjar/taxjar-php/compare/v1.9.0...v1.10.0

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ composer require taxjar/taxjar-php
 ```json
 {
   "require": {
-    "taxjar/taxjar-php": "^1.8"
+    "taxjar/taxjar-php": "^1.10"
   }
 }
 ```

--- a/lib/TaxJar.php
+++ b/lib/TaxJar.php
@@ -36,19 +36,15 @@ class TaxJar
             if ($response->getStatusCode() >= 400) {
                 $data = json_decode($response->getBody());
 
-                if ($data && $data->error && $data->detail) {
-                    throw new Exception(
-                        sprintf(
-                            '%s %s – %s',
-                            $response->getStatusCode(),
-                            $data->error,
-                            $data->detail
-                        ),
-                        $response->getStatusCode()
-                    );
-                }
-
-                throw new Exception($response);
+                throw new Exception(
+                    sprintf(
+                        '%s %s – %s',
+                        $response->getStatusCode(),
+                        isset($data->error) ? $data->error : 'something unexpected occurred',
+                        isset($data->detail) ? $data->detail: 'please try again'
+                    ),
+                    $response->getStatusCode()
+                );
             }
 
             return $response;

--- a/lib/TaxJar.php
+++ b/lib/TaxJar.php
@@ -3,7 +3,7 @@ namespace TaxJar;
 
 class TaxJar
 {
-    const VERSION = '1.10.2';
+    const VERSION = '1.10.3';
     const DEFAULT_API_URL = 'https://api.taxjar.com';
     const SANDBOX_API_URL = 'https://api.sandbox.taxjar.com';
     const API_VERSION = 'v2';

--- a/lib/TaxJar.php
+++ b/lib/TaxJar.php
@@ -41,7 +41,7 @@ class TaxJar
                         '%s %s – %s',
                         $response->getStatusCode(),
                         isset($data->error) ? $data->error : 'something unexpected occurred',
-                        isset($data->detail) ? $data->detail: 'please try again'
+                        isset($data->detail) ? $data->detail : 'please try again'
                     ),
                     $response->getStatusCode()
                 );


### PR DESCRIPTION
In #35 we fixed an issue where some exception details were being masked by improper formatting. This PR tweaks the solution so that default error messages are displayed when `$data->error` or `$data->detail` don't exist.