### PR TITLE
add php versions to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ php:
   - '7.0'
   - '7.1'
   - '7.2'
+  - '7.3'
+  - '7.4'
 
 before_script:
   - composer self-update


### PR DESCRIPTION
I noticed that the two latest versions of PHP weren't included. We'll be using this library and are running `7.4` so I wanted to make sure everything would be working ok.