### PR TITLE
Support Guzzle 7.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   ],
   "require": {
     "php": ">=5.5.0",
-    "guzzlehttp/guzzle": "^6.0.2"
+    "guzzlehttp/guzzle": "^7.0.1"
   },
   "require-dev": {
     "phpunit/phpunit": "4.8.*",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   ],
   "require": {
     "php": ">=5.5.0",
-    "guzzlehttp/guzzle": "^7.0.1"
+    "guzzlehttp/guzzle": "^6.0.2|^7.0.1"
   },
   "require-dev": {
     "phpunit/phpunit": "4.8.*",


### PR DESCRIPTION
We needed guzzlehttp 7.0.1  for our php framework so just updated composer and glad to see your tests passed.