### PR TITLE
Fixed API docs links in Client.php

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -15,7 +15,7 @@ class Client extends TaxJar
 
     /**
      * Get tax categories
-     * https://developers.taxjar.com/api/?php#list-tax-categories
+     * https://developers.taxjar.com/api/reference/?php#get-list-tax-categories
      *
      * @return object Collection of tax categories.
      */
@@ -44,7 +44,7 @@ class Client extends TaxJar
 
     /**
      * Get sales tax for an order
-     * https://developers.taxjar.com/api/?php#calculate-sales-tax-for-an-order
+     * hhttps://developers.taxjar.com/api/reference/?php#post-calculate-sales-tax-for-an-order
      *
      * @param array $parameters
      *
@@ -60,7 +60,7 @@ class Client extends TaxJar
 
     /**
      * List order transactions
-     * https://developers.taxjar.com/api/?php#list-order-transactions
+     * https://developers.taxjar.com/api/reference/?php#get-list-order-transactions
      *
      * @param array $parameters
      *
@@ -76,7 +76,7 @@ class Client extends TaxJar
 
     /**
      * Show order transaction
-     * https://developers.taxjar.com/api/?php#show-an-order-transaction
+     * https://developers.taxjar.com/api/reference/?php#get-show-an-order-transaction
      *
      * @param integer $transaction_id
      * @param array $parameters
@@ -93,7 +93,7 @@ class Client extends TaxJar
 
     /**
      * Create a new order transaction
-     * https://developers.taxjar.com/api/?php#create-an-order-transaction
+     * https://developers.taxjar.com/api/reference/?php#post-create-an-order-transaction
      *
      * @param array $parameters
      *
@@ -109,7 +109,7 @@ class Client extends TaxJar
 
     /**
      * Update an existing order transaction
-     * https://developers.taxjar.com/api/?php#update-an-order-transaction
+     * https://developers.taxjar.com/api/reference/?php#put-update-an-order-transaction
      *
      * @param integer @transaction_id
      * @param array $parameters
@@ -126,7 +126,7 @@ class Client extends TaxJar
 
     /**
      * Delete an existing order transaction
-     * https://developers.taxjar.com/api/?php#delete-an-order-transaction
+     * https://developers.taxjar.com/api/reference/?php#delete-delete-an-order-transaction
      *
      * @param integer $transaction_id
      * @param array $parameters
@@ -143,7 +143,7 @@ class Client extends TaxJar
 
     /**
      * List refund transactions
-     * https://developers.taxjar.com/api/?php#list-refund-transactions
+     * https://developers.taxjar.com/api/reference/?php#get-list-refund-transactions
      *
      * @param array $parameters
      *
@@ -159,7 +159,7 @@ class Client extends TaxJar
 
     /**
      * Show refund transaction
-     * https://developers.taxjar.com/api/?php#show-a-refund-transaction
+     * https://developers.taxjar.com/api/reference/?php#get-show-a-refund-transaction
      *
      * @param integer $transaction_id
      * @param array $parameters
@@ -176,7 +176,7 @@ class Client extends TaxJar
 
     /**
      * Create a new refund transaction
-     * https://developers.taxjar.com/api/?php#create-an-refund-transaction
+     * https://developers.taxjar.com/api/reference/?php#post-create-a-refund-transaction
      *
      * @param array $parameters
      *
@@ -192,7 +192,7 @@ class Client extends TaxJar
 
     /**
      * Update an order transaction
-     * https://developers.taxjar.com/api/?php#update-an-refund-transaction
+     * https://developers.taxjar.com/api/reference/?php#put-update-a-refund-transaction
      *
      * @param array $parameters
      *
@@ -208,7 +208,7 @@ class Client extends TaxJar
 
     /**
      * Delete an existing refund transaction
-     * https://developers.taxjar.com/api/?php#delete-a-refund-transaction
+     * https://developers.taxjar.com/api/reference/?php#delete-delete-a-refund-transaction
      *
      * @param integer $transaction_id
      * @param array $parameters
@@ -225,7 +225,7 @@ class Client extends TaxJar
 
     /**
      * List customers
-     * https://developers.taxjar.com/api/?php#get-list-customers
+     * https://developers.taxjar.com/api/reference/?php#get-list-customers
      *
      * @param array $parameters
      *
@@ -241,7 +241,7 @@ class Client extends TaxJar
 
     /**
      * Show customer
-     * https://developers.taxjar.com/api/?php#get-show-a-customer
+     * https://developers.taxjar.com/api/reference/?php#get-show-a-customer
      *
      * @param integer $customer_id
      *
@@ -255,7 +255,7 @@ class Client extends TaxJar
 
     /**
      * Create a new customer
-     * https://developers.taxjar.com/api/?php#post-create-a-customer
+     * https://developers.taxjar.com/api/reference/?php#post-create-a-customer
      *
      * @param array $parameters
      *
@@ -271,7 +271,7 @@ class Client extends TaxJar
 
     /**
      * Update a customer
-     * https://developers.taxjar.com/api/?php#put-update-a-customer
+     * https://developers.taxjar.com/api/reference/?php#put-update-a-customer
      *
      * @param integer @customer_id
      * @param array $parameters
@@ -288,7 +288,7 @@ class Client extends TaxJar
 
     /**
      * Delete a customer
-     * https://developers.taxjar.com/api/?php#delete-delete-a-customer
+     * https://developers.taxjar.com/api/reference/?php#delete-delete-a-customer
      *
      * @param integer $customer_id
      *

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -44,7 +44,7 @@ class Client extends TaxJar
 
     /**
      * Get sales tax for an order
-     * hhttps://developers.taxjar.com/api/reference/?php#post-calculate-sales-tax-for-an-order
+     * https://developers.taxjar.com/api/reference/?php#post-calculate-sales-tax-for-an-order
      *
      * @param array $parameters
      *


### PR DESCRIPTION
Many were missing "reference/" and/or their method type ("get-", "put-", etc.)