### PR TITLE
Keep reference to original response object in error cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,12 +473,15 @@ try {
       ]
     ]
   ]);
-} catch (TaxJar\Exception $e) {
+} catch (TaxJar\ApiException $e) {
   // 406 Not Acceptable – transaction_id is missing
   echo $e->getMessage();
 
   // 406
   echo $e->getStatusCode();
+
+  // Get the original response object
+  $e->getResponse();
 }
 ```
 

--- a/lib/ApiException.php
+++ b/lib/ApiException.php
@@ -1,0 +1,23 @@
+<?php
+namespace TaxJar;
+
+class ApiException extends Exception
+{
+    protected $response;
+
+    /**
+     * @param string $message
+     * @param \Psr\Http\Message\ResponseInterface$response
+     * @param \Throwable|null $previous
+     */
+    public function __construct($message, $response, $previous = null)
+    {
+        parent::__construct($message, $response->getStatusCode(), $previous);
+        $this->response = $response;
+    }
+
+    public function getResponse()
+    {
+        return $this->response;
+    }
+}

--- a/lib/ApiException.php
+++ b/lib/ApiException.php
@@ -3,11 +3,14 @@ namespace TaxJar;
 
 class ApiException extends Exception
 {
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
     protected $response;
 
     /**
      * @param string $message
-     * @param \Psr\Http\Message\ResponseInterface$response
+     * @param \Psr\Http\Message\ResponseInterface $response
      * @param \Throwable|null $previous
      */
     public function __construct($message, $response, $previous = null)
@@ -16,6 +19,9 @@ class ApiException extends Exception
         $this->response = $response;
     }
 
+    /**
+     * @return \Psr\Http\Message\ResponseInterface
+     */
     public function getResponse()
     {
         return $this->response;

--- a/lib/TaxJar.php
+++ b/lib/TaxJar.php
@@ -36,14 +36,14 @@ class TaxJar
             if ($response->getStatusCode() >= 400) {
                 $data = json_decode($response->getBody());
 
-                throw new Exception(
+                throw new ApiException(
                     sprintf(
                         '%s %s – %s',
                         $response->getStatusCode(),
                         isset($data->error) ? $data->error : 'something unexpected occurred',
                         isset($data->detail) ? $data->detail : 'please try again'
                     ),
-                    $response->getStatusCode()
+                    $response
                 );
             }
 


### PR DESCRIPTION
Sometimes, you need to handle error cases differently depending on what
the actual error was.  For example, zipcode errors would be handled
differently than missing line items.  By keeping a reference to the
original object, it's easier to programatically parse and understand the
error message rather than trying to trying to check whether some
substring is in the error message.
    
This change should be 100% backwards compatible but provides an
enhancement for future users.