### PR TITLE
PHP 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,22 +7,11 @@ php:
   - 7.2
   - 7.3
   - 7.4
-
-env:
-  - HTTPMOCK_VERSION="^0.13.0"
-
-matrix:
-  include:
-    - php: 5.5
-      env: HTTPMOCK_VERSION="0.10.1"
-    - php: 5.6
-      env: HTTPMOCK_VERSION="0.10.1"
-    - php: 7.0
-      env: HTTPMOCK_VERSION="0.10.1"
+  - 8.0
+  - 8.1
 
 before_script:
   - composer self-update
-  - composer require "internations/http-mock:${HTTPMOCK_VERSION}" --no-update
   - composer install
 
-script: php vendor/bin/phpunit test/specs/.
+script: composer tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 
-dist: trusty
+dist: focal
 
 php:
-  - 7.1
   - 7.2
   - 7.3
   - 7.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 
-dist: focal
-
 php:
   - 7.2
   - 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ php:
   - 7.3
   - 7.4
   - 8.0
-  - 8.1
+  - 8.1.0
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
     }
   ],
   "require": {
-    "php": "^7.1|^8.0",
+    "php": "^7.2|^8.0",
     "ext-json": "*",
     "guzzlehttp/guzzle": "^6.0.2|^7.0.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.5"
+    "phpunit/phpunit": "^8.5"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,24 @@
     }
   ],
   "require": {
-    "php": ">=5.5.0",
+    "php": "^7.1|^8.0",
+    "ext-json": "*",
     "guzzlehttp/guzzle": "^6.0.2|^7.0.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.8.*",
-    "internations/http-mock": "^0.13.0",
-    "silex/silex": "2.2.2"
+    "phpunit/phpunit": "^9.5"
   },
   "autoload": {
-    "psr-4": { "TaxJar\\" : "lib/" }
+    "psr-4": {
+      "TaxJar\\" : "lib/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "TaxJar\\Tests\\": "test/"
+    }
+  },
+  "scripts": {
+    "tests": "phpunit"
   }
 }

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -8,11 +8,6 @@ class Client extends TaxJar
         return new Client($key);
     }
 
-    public function __construct($key)
-    {
-        parent::__construct($key);
-    }
-
     /**
      * Get tax categories
      * https://developers.taxjar.com/api/?php#list-tax-categories

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit bootstrap = "vendor/autoload.php"
+         backupGlobals               = "false"
+         backupStaticAttributes      = "false"
+         colors                      = "true"
+         convertErrorsToExceptions   = "true"
+         convertNoticesToExceptions  = "true"
+         convertWarningsToExceptions = "true"
+         processIsolation            = "false"
+         stopOnFailure               = "false">
+
+    <testsuites>
+        <testsuite name="taxjar-php">
+            <directory>test</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/TaxJarTest.php
+++ b/test/TaxJarTest.php
@@ -1,31 +1,31 @@
 <?php
-require 'vendor/autoload.php';
 
-class TaxJarTest extends PHPUnit_Framework_TestCase
+namespace TaxJar\Tests;
+
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use PHPUnit\Framework\TestCase;
+use TaxJar\Client;
+
+abstract class TaxJarTest extends TestCase
 {
+    protected $history = [];
+
+    /** @var MockHandler */
+    protected $http;
+
+    /** @var Client */
     protected $client;
 
-    use \InterNations\Component\HttpMock\PHPUnit\HttpMockTrait;
-
-    public static function setUpBeforeClass()
+    public function setUp(): void
     {
-        static::setUpHttpMockBeforeClass('8082', 'localhost');
-    }
+        $this->http = new MockHandler();
+        $handler = HandlerStack::create($this->http);
+        $handler->push(Middleware::history($this->history));
 
-    public static function tearDownAfterClass()
-    {
-        static::tearDownHttpMockAfterClass();
-    }
-
-    public function setUp()
-    {
-        $this->setUpHttpMock();
-        $this->client = TaxJar\Client::withApiKey('test');
+        $this->client = Client::withApiKey('test');
+        $this->client->setApiConfig('handler', $handler);
         $this->client->setApiConfig('base_uri', 'http://localhost:8082');
-    }
-
-    public function tearDown()
-    {
-        $this->tearDownHttpMock();
     }
 }

--- a/test/specs/CategoryTest.php
+++ b/test/specs/CategoryTest.php
@@ -1,24 +1,25 @@
 <?php
-if (!class_exists('TaxJarTest')) {
-    require __DIR__ . '/../TaxJarTest.php';
-}
+
+namespace TaxJar\Tests\specs;
+
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use TaxJar\Tests\TaxJarTest;
 
 class CategoryTest extends TaxJarTest
 {
     public function testCategories()
     {
-        $this->http->mock
-            ->when()
-            ->methodIs('GET')
-            ->pathIs('/categories')
-            ->then()
-            ->statusCode(200)
-            ->body(file_get_contents(__DIR__ . "/../fixtures/categories.json"))
-            ->end();
-
-        $this->http->setUp();
+        $this->http->append(new Response(200, [], file_get_contents(__DIR__ . "/../fixtures/categories.json")));
 
         $response = $this->client->categories();
+
+        $this->assertCount(1, $this->history);
+
+        /** @var Request $request */
+        $request = reset($this->history)['request'];
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('/categories', $request->getUri()->getPath());
 
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/categories.json', json_encode([
             "categories" => $response

--- a/test/specs/ConfigTest.php
+++ b/test/specs/ConfigTest.php
@@ -34,7 +34,7 @@ class ConfigTest extends TaxJarTest
 
         $this->assertEquals($headers['Authorization'], 'Bearer test');
         $this->assertEquals($headers['Content-Type'], 'application/json');
-        $this->assertMatchesRegularExpression('/TaxJar\/PHP \(.*\) taxjar-php\/\d+\.\d+\.\d+/', $headers['User-Agent']);
+        $this->assertRegExp('/TaxJar\/PHP \(.*\) taxjar-php\/\d+\.\d+\.\d+/', $headers['User-Agent']);
     }
 
     public function testSetCustomHeaders()
@@ -48,6 +48,6 @@ class ConfigTest extends TaxJarTest
         $this->assertEquals($headers['Authorization'], 'Bearer test');
         $this->assertEquals($headers['Content-Type'], 'application/json');
         $this->assertEquals($headers['X-TJ-Expected-Response'], 422);
-        $this->assertMatchesRegularExpression('/TaxJar\/PHP \(.*\) taxjar-php\/\d+\.\d+\.\d+/', $headers['User-Agent']);
+        $this->assertRegExp('/TaxJar\/PHP \(.*\) taxjar-php\/\d+\.\d+\.\d+/', $headers['User-Agent']);
     }
 }

--- a/test/specs/ConfigTest.php
+++ b/test/specs/ConfigTest.php
@@ -1,7 +1,8 @@
 <?php
-if (!class_exists('TaxJarTest')) {
-    require __DIR__ . '/../TaxJarTest.php';
-}
+
+namespace TaxJar\Tests\specs;
+
+use TaxJar\Tests\TaxJarTest;
 
 class ConfigTest extends TaxJarTest
 {
@@ -33,7 +34,7 @@ class ConfigTest extends TaxJarTest
 
         $this->assertEquals($headers['Authorization'], 'Bearer test');
         $this->assertEquals($headers['Content-Type'], 'application/json');
-        $this->assertRegExp('/TaxJar\/PHP \(.*\) taxjar-php\/\d+\.\d+\.\d+/', $headers['User-Agent']);
+        $this->assertMatchesRegularExpression('/TaxJar\/PHP \(.*\) taxjar-php\/\d+\.\d+\.\d+/', $headers['User-Agent']);
     }
 
     public function testSetCustomHeaders()
@@ -47,6 +48,6 @@ class ConfigTest extends TaxJarTest
         $this->assertEquals($headers['Authorization'], 'Bearer test');
         $this->assertEquals($headers['Content-Type'], 'application/json');
         $this->assertEquals($headers['X-TJ-Expected-Response'], 422);
-        $this->assertRegExp('/TaxJar\/PHP \(.*\) taxjar-php\/\d+\.\d+\.\d+/', $headers['User-Agent']);
+        $this->assertMatchesRegularExpression('/TaxJar\/PHP \(.*\) taxjar-php\/\d+\.\d+\.\d+/', $headers['User-Agent']);
     }
 }

--- a/test/specs/CustomerTest.php
+++ b/test/specs/CustomerTest.php
@@ -1,24 +1,25 @@
 <?php
-if (!class_exists('TaxJarTest')) {
-    require __DIR__ . '/../TaxJarTest.php';
-}
+
+namespace TaxJar\Tests\specs;
+
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use TaxJar\Tests\TaxJarTest;
 
 class CustomerTest extends TaxJarTest
 {
     public function testListCustomers()
     {
-        $this->http->mock
-            ->when()
-            ->methodIs('GET')
-            ->pathIs('/customers')
-            ->then()
-            ->statusCode(200)
-            ->body(file_get_contents(__DIR__ . "/../fixtures/customers/list.json"))
-            ->end();
-
-        $this->http->setUp();
+        $this->http->append(new Response(200, [], file_get_contents(__DIR__ . "/../fixtures/customers/list.json")));
 
         $response = $this->client->listCustomers();
+
+        $this->assertCount(1, $this->history);
+
+        /** @var Request $request */
+        $request = reset($this->history)['request'];
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('/customers', $request->getUri()->getPath());
 
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/customers/list.json', json_encode([
             "customers" => $response
@@ -27,18 +28,16 @@ class CustomerTest extends TaxJarTest
 
     public function testShowCustomer()
     {
-        $this->http->mock
-            ->when()
-            ->methodIs('GET')
-            ->pathIs('/customers/123')
-            ->then()
-            ->statusCode(200)
-            ->body(file_get_contents(__DIR__ . "/../fixtures/customers/show.json"))
-            ->end();
-
-        $this->http->setUp();
+        $this->http->append(new Response(200, [], file_get_contents(__DIR__ . "/../fixtures/customers/show.json")));
 
         $response = $this->client->showCustomer(123);
+
+        $this->assertCount(1, $this->history);
+
+        /** @var Request $request */
+        $request = reset($this->history)['request'];
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('/customers/123', $request->getUri()->getPath());
 
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/customers/show.json', json_encode([
             "customer" => $response
@@ -47,16 +46,7 @@ class CustomerTest extends TaxJarTest
 
     public function testCreateCustomer()
     {
-        $this->http->mock
-            ->when()
-            ->methodIs('POST')
-            ->pathIs('/customers')
-            ->then()
-            ->statusCode(201)
-            ->body(file_get_contents(__DIR__ . "/../fixtures/customers/show.json"))
-            ->end();
-
-        $this->http->setUp();
+        $this->http->append(new Response(201, [], file_get_contents(__DIR__ . "/../fixtures/customers/show.json")));
 
         $response = $this->client->createCustomer([
             'customer_id' => '123',
@@ -79,6 +69,13 @@ class CustomerTest extends TaxJarTest
             'street' => '1725 Slough Avenue'
         ]);
 
+        $this->assertCount(1, $this->history);
+
+        /** @var Request $request */
+        $request = reset($this->history)['request'];
+        $this->assertSame('POST', $request->getMethod());
+        $this->assertSame('/customers', $request->getUri()->getPath());
+
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/customers/show.json', json_encode([
             "customer" => $response
         ]));
@@ -86,16 +83,7 @@ class CustomerTest extends TaxJarTest
 
     public function testUpdateCustomer()
     {
-        $this->http->mock
-            ->when()
-            ->methodIs('PUT')
-            ->pathIs('/customers/123')
-            ->then()
-            ->statusCode(200)
-            ->body(file_get_contents(__DIR__ . "/../fixtures/customers/show.json"))
-            ->end();
-
-        $this->http->setUp();
+        $this->http->append(new Response(200, [], file_get_contents(__DIR__ . "/../fixtures/customers/show.json")));
 
         $response = $this->client->updateCustomer([
             'customer_id' => '123',
@@ -114,6 +102,13 @@ class CustomerTest extends TaxJarTest
             'street' => '405 Madison Ave'
         ]);
 
+        $this->assertCount(1, $this->history);
+
+        /** @var Request $request */
+        $request = reset($this->history)['request'];
+        $this->assertSame('PUT', $request->getMethod());
+        $this->assertSame('/customers/123', $request->getUri()->getPath());
+
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/customers/show.json', json_encode([
             "customer" => $response
         ]));
@@ -121,18 +116,16 @@ class CustomerTest extends TaxJarTest
 
     public function testDeleteCustomer()
     {
-        $this->http->mock
-            ->when()
-            ->methodIs('DELETE')
-            ->pathIs('/customers/123')
-            ->then()
-            ->statusCode(200)
-            ->body(file_get_contents(__DIR__ . "/../fixtures/customers/show.json"))
-            ->end();
-
-        $this->http->setUp();
+        $this->http->append(new Response(200, [], file_get_contents(__DIR__ . "/../fixtures/customers/show.json")));
 
         $response = $this->client->deleteCustomer(123);
+
+        $this->assertCount(1, $this->history);
+
+        /** @var Request $request */
+        $request = reset($this->history)['request'];
+        $this->assertSame('DELETE', $request->getMethod());
+        $this->assertSame('/customers/123', $request->getUri()->getPath());
 
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/customers/show.json', json_encode([
             "customer" => $response

--- a/test/specs/NexusRegionTest.php
+++ b/test/specs/NexusRegionTest.php
@@ -1,24 +1,25 @@
 <?php
-if (!class_exists('TaxJarTest')) {
-    require __DIR__ . '/../TaxJarTest.php';
-}
+
+namespace TaxJar\Tests\specs;
+
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use TaxJar\Tests\TaxJarTest;
 
 class NexusRegionTest extends TaxJarTest
 {
     public function testNexusRegions()
     {
-        $this->http->mock
-            ->when()
-            ->methodIs('GET')
-            ->pathIs('/nexus/regions')
-            ->then()
-            ->statusCode(200)
-            ->body(file_get_contents(__DIR__ . "/../fixtures/nexus_regions.json"))
-            ->end();
-
-        $this->http->setUp();
+        $this->http->append(new Response(200, [], file_get_contents(__DIR__ . "/../fixtures/nexus_regions.json")));
 
         $response = $this->client->nexusRegions();
+
+        $this->assertCount(1, $this->history);
+
+        /** @var Request $request */
+        $request = reset($this->history)['request'];
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('/nexus/regions', $request->getUri()->getPath());
 
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/nexus_regions.json', json_encode([
             "regions" => $response,

--- a/test/specs/RateTest.php
+++ b/test/specs/RateTest.php
@@ -1,24 +1,25 @@
 <?php
-if (!class_exists('TaxJarTest')) {
-    require __DIR__ . '/../TaxJarTest.php';
-}
+
+namespace TaxJar\Tests\specs;
+
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use TaxJar\Tests\TaxJarTest;
 
 class RateTest extends TaxJarTest
 {
     public function testRatesForLocation()
     {
-        $this->http->mock
-            ->when()
-            ->methodIs('GET')
-            ->pathIs('/rates/90002')
-            ->then()
-            ->statusCode(200)
-            ->body(file_get_contents(__DIR__ . "/../fixtures/rates.json"))
-            ->end();
-
-        $this->http->setUp();
+        $this->http->append(new Response(200, [], file_get_contents(__DIR__ . "/../fixtures/rates.json")));
 
         $response = $this->client->ratesForLocation(90002);
+
+        $this->assertCount(1, $this->history);
+
+        /** @var Request $request */
+        $request = reset($this->history)['request'];
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('/rates/90002', $request->getUri()->getPath());
 
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/rates.json', json_encode([
             "rate" => $response,

--- a/test/specs/SummaryRateTest.php
+++ b/test/specs/SummaryRateTest.php
@@ -1,24 +1,25 @@
 <?php
-if (!class_exists('TaxJarTest')) {
-    require __DIR__ . '/../TaxJarTest.php';
-}
+
+namespace TaxJar\Tests\specs;
+
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use TaxJar\Tests\TaxJarTest;
 
 class SummaryRateTest extends TaxJarTest
 {
     public function testSummaryRates()
     {
-        $this->http->mock
-            ->when()
-            ->methodIs('GET')
-            ->pathIs('/summary_rates')
-            ->then()
-            ->statusCode(200)
-            ->body(file_get_contents(__DIR__ . "/../fixtures/summary_rates.json"))
-            ->end();
-
-        $this->http->setUp();
+        $this->http->append(new Response(200, [], file_get_contents(__DIR__ . "/../fixtures/summary_rates.json")));
 
         $response = $this->client->summaryRates();
+
+        $this->assertCount(1, $this->history);
+
+        /** @var Request $request */
+        $request = reset($this->history)['request'];
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('/summary_rates', $request->getUri()->getPath());
 
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/summary_rates.json', json_encode([
             "summary_rates" => $response

--- a/test/specs/TokenTest.php
+++ b/test/specs/TokenTest.php
@@ -1,14 +1,19 @@
 <?php
-if (!class_exists('TaxJarTest')) {
-    require __DIR__ . '/../TaxJarTest.php';
-}
+
+namespace TaxJar\Tests\specs;
+
+use Exception;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Psr7\Response;
+use TaxJar\Client;
+use TaxJar\Tests\TaxJarTest;
 
 class TokenTest extends TaxJarTest
 {
     public function testTokenException()
     {
         try {
-            $this->client = TaxJar\Client::withApiKey(null);
+            $this->client = Client::withApiKey(null);
         } catch (Exception $e) {
             $this->assertEquals($e->getMessage(), 'Please provide an API key.');
             $this->assertEquals($e->getStatusCode(), 0);
@@ -18,50 +23,32 @@ class TokenTest extends TaxJarTest
     public function testUnauthorizedTokenException()
     {
         try {
-            $this->http->mock
-                ->when()
-                ->methodIs('GET')
-                ->pathIs('/categories')
-                ->then()
-                ->statusCode(401)
-                ->body(json_encode([
-                    'error' => "Unauthorized",
-                    'detail' => "Not authorized for route 'GET /v2/categories'",
-                    'status' => 401,
-                ]))
-                ->end();
-
-            $this->http->setUp();
+            $this->http->append(new Response(401, [], json_encode([
+                'error' => "Unauthorized",
+                'detail' => "Not authorized for route 'GET /v2/categories'",
+                'status' => 401,
+            ])));
 
             $response = $this->client->categories();
-        } catch (Exception $e) {
-            $this->assertEquals($e->getMessage(), "401 Unauthorized – Not authorized for route 'GET /v2/categories'");
-            $this->assertEquals($e->getStatusCode(), 401);
+        } catch (ClientException $e) {
+            $this->assertStringContainsString('Client error: `GET http://localhost:8082/categories` resulted in a `401 Unauthorized` response:', $e->getMessage());
+            $this->assertEquals($e->getCode(), 401);
         }
     }
 
     public function testExpiredTokenException()
     {
         try {
-            $this->http->mock
-                ->when()
-                ->methodIs('GET')
-                ->pathIs('/categories')
-                ->then()
-                ->statusCode(403)
-                ->body(json_encode([
-                    'error' => "Forbidden",
-                    'detail' => "Not authorized for resource",
-                    'status' => 403,
-                ]))
-                ->end();
-
-            $this->http->setUp();
+            $this->http->append(new Response(403, [], json_encode([
+                'error' => "Forbidden",
+                'detail' => "Not authorized for resource",
+                'status' => 403,
+            ])));
 
             $response = $this->client->categories();
-        } catch (Exception $e) {
-            $this->assertEquals($e->getMessage(), "403 Forbidden – Not authorized for resource");
-            $this->assertEquals($e->getStatusCode(), 403);
+        } catch (ClientException $e) {
+            $this->assertStringContainsString('Client error: `GET http://localhost:8082/categories` resulted in a `403 Forbidden` response', $e->getMessage());
+            $this->assertEquals($e->getCode(), 403);
         }
     }
 }

--- a/test/specs/TransactionTest.php
+++ b/test/specs/TransactionTest.php
@@ -1,33 +1,29 @@
 <?php
-if (!class_exists('TaxJarTest')) {
-    require __DIR__ . '/../TaxJarTest.php';
-}
+
+namespace TaxJar\Tests\specs;
+
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use TaxJar\Tests\TaxJarTest;
 
 class TransactionTest extends TaxJarTest
 {
     public function testListOrders()
     {
-        $queryString = version_compare(PHP_VERSION, '7.1.0', '<') ? '?from_transaction_date=2015%2F05%2F01&to_transaction_date=2015%2F05%2F31' : '';
-
-        $this->http->mock
-            ->when()
-            ->methodIs('GET')
-            ->pathIs('/transactions/orders' . $queryString)
-            ->queryParamsAre([
-                'from_transaction_date' => '2015/05/01',
-                'to_transaction_date' => '2015/05/31'
-            ])
-            ->then()
-            ->statusCode(200)
-            ->body(file_get_contents(__DIR__ . "/../fixtures/orders/list.json"))
-            ->end();
-
-        $this->http->setUp();
+        $this->http->append(new Response(200, [], file_get_contents(__DIR__ . "/../fixtures/orders/list.json")));
 
         $response = $this->client->listOrders([
             'from_transaction_date' => '2015/05/01',
             'to_transaction_date' => '2015/05/31',
         ]);
+
+        $this->assertCount(1, $this->history);
+
+        /** @var Request $request */
+        $request = reset($this->history)['request'];
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('/transactions/orders', $request->getUri()->getPath());
+        $this->assertSame('from_transaction_date=2015%2F05%2F01&to_transaction_date=2015%2F05%2F31', $request->getUri()->getQuery());
 
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/orders/list.json', json_encode([
             "orders" => $response
@@ -36,18 +32,16 @@ class TransactionTest extends TaxJarTest
 
     public function testShowOrder()
     {
-        $this->http->mock
-            ->when()
-            ->methodIs('GET')
-            ->pathIs('/transactions/orders/123')
-            ->then()
-            ->statusCode(200)
-            ->body(file_get_contents(__DIR__ . "/../fixtures/orders/show.json"))
-            ->end();
-
-        $this->http->setUp();
+        $this->http->append(new Response(200, [], file_get_contents(__DIR__ . "/../fixtures/orders/show.json")));
 
         $response = $this->client->showOrder(123);
+
+        $this->assertCount(1, $this->history);
+
+        /** @var Request $request */
+        $request = reset($this->history)['request'];
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('/transactions/orders/123', $request->getUri()->getPath());
 
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/orders/show.json', json_encode([
             "order" => $response
@@ -56,23 +50,19 @@ class TransactionTest extends TaxJarTest
 
     public function testShowOrderWithParams()
     {
-        $queryString = version_compare(PHP_VERSION, '7.1.0', '<') ? '?provider=api' : '';
-
-        $this->http->mock
-            ->when()
-            ->methodIs('GET')
-            ->pathIs('/transactions/orders/123' . $queryString)
-            ->queryParamIs('provider', 'api')
-            ->then()
-            ->statusCode(200)
-            ->body(file_get_contents(__DIR__ . "/../fixtures/orders/show.json"))
-            ->end();
-
-        $this->http->setUp();
+        $this->http->append(new Response(200, [], file_get_contents(__DIR__ . "/../fixtures/orders/show.json")));
 
         $response = $this->client->showOrder(123, [
             'provider' => 'api',
         ]);
+
+        $this->assertCount(1, $this->history);
+
+        /** @var Request $request */
+        $request = reset($this->history)['request'];
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('/transactions/orders/123', $request->getUri()->getPath());
+        $this->assertSame('provider=api', $request->getUri()->getQuery());
 
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/orders/show.json', json_encode([
             "order" => $response
@@ -81,16 +71,7 @@ class TransactionTest extends TaxJarTest
 
     public function testCreateOrder()
     {
-        $this->http->mock
-            ->when()
-            ->methodIs('POST')
-            ->pathIs('/transactions/orders')
-            ->then()
-            ->statusCode(201)
-            ->body(file_get_contents(__DIR__ . "/../fixtures/orders/show.json"))
-            ->end();
-
-        $this->http->setUp();
+        $this->http->append(new Response(201, [], file_get_contents(__DIR__ . "/../fixtures/orders/show.json")));
 
         $response = $this->client->createOrder([
             'transaction_id' => '123',
@@ -114,6 +95,13 @@ class TransactionTest extends TaxJarTest
             ],
         ]);
 
+        $this->assertCount(1, $this->history);
+
+        /** @var Request $request */
+        $request = reset($this->history)['request'];
+        $this->assertSame('POST', $request->getMethod());
+        $this->assertSame('/transactions/orders', $request->getUri()->getPath());
+
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/orders/show.json', json_encode([
             "order" => $response
         ]));
@@ -121,16 +109,7 @@ class TransactionTest extends TaxJarTest
 
     public function testUpdateOrder()
     {
-        $this->http->mock
-            ->when()
-            ->methodIs('PUT')
-            ->pathIs('/transactions/orders/123')
-            ->then()
-            ->statusCode(200)
-            ->body(file_get_contents(__DIR__ . "/../fixtures/orders/show.json"))
-            ->end();
-
-        $this->http->setUp();
+        $this->http->append(new Response(200, [], file_get_contents(__DIR__ . "/../fixtures/orders/show.json")));
 
         $response = $this->client->updateOrder([
             'transaction_id' => '123',
@@ -148,6 +127,13 @@ class TransactionTest extends TaxJarTest
             ],
         ]);
 
+        $this->assertCount(1, $this->history);
+
+        /** @var Request $request */
+        $request = reset($this->history)['request'];
+        $this->assertSame('PUT', $request->getMethod());
+        $this->assertSame('/transactions/orders/123', $request->getUri()->getPath());
+
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/orders/show.json', json_encode([
             "order" => $response
         ]));
@@ -155,18 +141,16 @@ class TransactionTest extends TaxJarTest
 
     public function testDeleteOrder()
     {
-        $this->http->mock
-            ->when()
-            ->methodIs('DELETE')
-            ->pathIs('/transactions/orders/123')
-            ->then()
-            ->statusCode(200)
-            ->body(file_get_contents(__DIR__ . "/../fixtures/orders/show.json"))
-            ->end();
-
-        $this->http->setUp();
+        $this->http->append(new Response(200, [], file_get_contents(__DIR__ . "/../fixtures/orders/show.json")));
 
         $response = $this->client->deleteOrder(123);
+
+        $this->assertCount(1, $this->history);
+
+        /** @var Request $request */
+        $request = reset($this->history)['request'];
+        $this->assertSame('DELETE', $request->getMethod());
+        $this->assertSame('/transactions/orders/123', $request->getUri()->getPath());
 
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/orders/show.json', json_encode([
             "order" => $response
@@ -175,23 +159,19 @@ class TransactionTest extends TaxJarTest
 
     public function testDeleteOrderWithParams()
     {
-        $queryString = version_compare(PHP_VERSION, '7.1.0', '<') ? '?provider=api' : '';
-
-        $this->http->mock
-            ->when()
-            ->methodIs('DELETE')
-            ->pathIs('/transactions/orders/123' . $queryString)
-            ->queryParamIs('provider', 'api')
-            ->then()
-            ->statusCode(200)
-            ->body(file_get_contents(__DIR__ . "/../fixtures/orders/show.json"))
-            ->end();
-
-        $this->http->setUp();
+        $this->http->append(new Response(200, [], file_get_contents(__DIR__ . "/../fixtures/orders/show.json")));
 
         $response = $this->client->deleteOrder(123, [
             'provider' => 'api',
         ]);
+
+        $this->assertCount(1, $this->history);
+
+        /** @var Request $request */
+        $request = reset($this->history)['request'];
+        $this->assertSame('DELETE', $request->getMethod());
+        $this->assertSame('/transactions/orders/123', $request->getUri()->getPath());
+        $this->assertSame('provider=api', $request->getUri()->getQuery());
 
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/orders/show.json', json_encode([
             "order" => $response
@@ -200,27 +180,20 @@ class TransactionTest extends TaxJarTest
 
     public function testListRefunds()
     {
-        $queryString = version_compare(PHP_VERSION, '7.1.0', '<') ? '?from_transaction_date=2015%2F05%2F01&to_transaction_date=2015%2F05%2F31' : '';
-
-        $this->http->mock
-            ->when()
-            ->methodIs('GET')
-            ->pathIs('/transactions/refunds' . $queryString)
-            ->queryParamsAre([
-                'from_transaction_date' => '2015/05/01',
-                'to_transaction_date' => '2015/05/31'
-            ])
-            ->then()
-            ->statusCode(200)
-            ->body(file_get_contents(__DIR__ . "/../fixtures/refunds/list.json"))
-            ->end();
-
-        $this->http->setUp();
+        $this->http->append(new Response(200, [], file_get_contents(__DIR__ . "/../fixtures/refunds/list.json")));
 
         $response = $this->client->listRefunds([
             'from_transaction_date' => '2015/05/01',
             'to_transaction_date' => '2015/05/31',
         ]);
+
+        $this->assertCount(1, $this->history);
+
+        /** @var Request $request */
+        $request = reset($this->history)['request'];
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('/transactions/refunds', $request->getUri()->getPath());
+        $this->assertSame('from_transaction_date=2015%2F05%2F01&to_transaction_date=2015%2F05%2F31', $request->getUri()->getQuery());
 
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/refunds/list.json', json_encode([
             "refunds" => $response
@@ -229,18 +202,16 @@ class TransactionTest extends TaxJarTest
 
     public function testShowRefund()
     {
-        $this->http->mock
-            ->when()
-            ->methodIs('GET')
-            ->pathIs('/transactions/refunds/321')
-            ->then()
-            ->statusCode(200)
-            ->body(file_get_contents(__DIR__ . "/../fixtures/refunds/show.json"))
-            ->end();
-
-        $this->http->setUp();
+        $this->http->append(new Response(200, [], file_get_contents(__DIR__ . "/../fixtures/refunds/show.json")));
 
         $response = $this->client->showRefund(321);
+
+        $this->assertCount(1, $this->history);
+
+        /** @var Request $request */
+        $request = reset($this->history)['request'];
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('/transactions/refunds/321', $request->getUri()->getPath());
 
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/refunds/show.json', json_encode([
             "refund" => $response
@@ -249,23 +220,19 @@ class TransactionTest extends TaxJarTest
 
     public function testShowRefundWithParams()
     {
-        $queryString = version_compare(PHP_VERSION, '7.1.0', '<') ? '?provider=api' : '';
-
-        $this->http->mock
-            ->when()
-            ->methodIs('GET')
-            ->pathIs('/transactions/refunds/321' . $queryString)
-            ->queryParamIs('provider', 'api')
-            ->then()
-            ->statusCode(200)
-            ->body(file_get_contents(__DIR__ . "/../fixtures/refunds/show.json"))
-            ->end();
-
-        $this->http->setUp();
+        $this->http->append(new Response(200, [], file_get_contents(__DIR__ . "/../fixtures/refunds/show.json")));
 
         $response = $this->client->showRefund(321, [
             'provider' => 'api',
         ]);
+
+        $this->assertCount(1, $this->history);
+
+        /** @var Request $request */
+        $request = reset($this->history)['request'];
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('/transactions/refunds/321', $request->getUri()->getPath());
+        $this->assertSame('provider=api', $request->getUri()->getQuery());
 
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/refunds/show.json', json_encode([
             "refund" => $response
@@ -274,16 +241,7 @@ class TransactionTest extends TaxJarTest
 
     public function testCreateRefund()
     {
-        $this->http->mock
-            ->when()
-            ->methodIs('POST')
-            ->pathIs('/transactions/refunds')
-            ->then()
-            ->statusCode(201)
-            ->body(file_get_contents(__DIR__ . "/../fixtures/refunds/show.json"))
-            ->end();
-
-        $this->http->setUp();
+        $this->http->append(new Response(201, [], file_get_contents(__DIR__ . "/../fixtures/refunds/show.json")));
 
         $response = $this->client->createRefund([
             'transaction_id' => '321',
@@ -308,6 +266,13 @@ class TransactionTest extends TaxJarTest
             ],
         ]);
 
+        $this->assertCount(1, $this->history);
+
+        /** @var Request $request */
+        $request = reset($this->history)['request'];
+        $this->assertSame('POST', $request->getMethod());
+        $this->assertSame('/transactions/refunds', $request->getUri()->getPath());
+
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/refunds/show.json', json_encode([
             "refund" => $response
         ]));
@@ -315,16 +280,7 @@ class TransactionTest extends TaxJarTest
 
     public function testUpdateRefund()
     {
-        $this->http->mock
-            ->when()
-            ->methodIs('PUT')
-            ->pathIs('/transactions/refunds/321')
-            ->then()
-            ->statusCode(200)
-            ->body(file_get_contents(__DIR__ . "/../fixtures/refunds/show.json"))
-            ->end();
-
-        $this->http->setUp();
+        $this->http->append(new Response(200, [], file_get_contents(__DIR__ . "/../fixtures/refunds/show.json")));
 
         $response = $this->client->updateRefund([
             'transaction_id' => '321',
@@ -341,6 +297,13 @@ class TransactionTest extends TaxJarTest
             ],
         ]);
 
+        $this->assertCount(1, $this->history);
+
+        /** @var Request $request */
+        $request = reset($this->history)['request'];
+        $this->assertSame('PUT', $request->getMethod());
+        $this->assertSame('/transactions/refunds/321', $request->getUri()->getPath());
+
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/refunds/show.json', json_encode([
             "refund" => $response
         ]));
@@ -348,18 +311,16 @@ class TransactionTest extends TaxJarTest
 
     public function testDeleteRefund()
     {
-        $this->http->mock
-            ->when()
-            ->methodIs('DELETE')
-            ->pathIs('/transactions/refunds/321')
-            ->then()
-            ->statusCode(200)
-            ->body(file_get_contents(__DIR__ . "/../fixtures/refunds/show.json"))
-            ->end();
-
-        $this->http->setUp();
+        $this->http->append(new Response(200, [], file_get_contents(__DIR__ . "/../fixtures/refunds/show.json")));
 
         $response = $this->client->deleteRefund(321);
+
+        $this->assertCount(1, $this->history);
+
+        /** @var Request $request */
+        $request = reset($this->history)['request'];
+        $this->assertSame('DELETE', $request->getMethod());
+        $this->assertSame('/transactions/refunds/321', $request->getUri()->getPath());
 
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/refunds/show.json', json_encode([
             "refund" => $response
@@ -368,23 +329,19 @@ class TransactionTest extends TaxJarTest
 
     public function testDeleteRefundWithParams()
     {
-        $queryString = version_compare(PHP_VERSION, '7.1.0', '<') ? '?provider=api' : '';
-
-        $this->http->mock
-            ->when()
-            ->methodIs('DELETE')
-            ->pathIs('/transactions/refunds/321' . $queryString)
-            ->queryParamIs('provider', 'api')
-            ->then()
-            ->statusCode(200)
-            ->body(file_get_contents(__DIR__ . "/../fixtures/refunds/show.json"))
-            ->end();
-
-        $this->http->setUp();
+        $this->http->append(new Response(200, [], file_get_contents(__DIR__ . "/../fixtures/refunds/show.json")));
 
         $response = $this->client->deleteRefund(321, [
             'provider' => 'api',
         ]);
+
+        $this->assertCount(1, $this->history);
+
+        /** @var Request $request */
+        $request = reset($this->history)['request'];
+        $this->assertSame('DELETE', $request->getMethod());
+        $this->assertSame('/transactions/refunds/321', $request->getUri()->getPath());
+        $this->assertSame('provider=api', $request->getUri()->getQuery());
 
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/refunds/show.json', json_encode([
             "refund" => $response

--- a/test/specs/ValidationTest.php
+++ b/test/specs/ValidationTest.php
@@ -1,22 +1,16 @@
 <?php
-if (!class_exists('TaxJarTest')) {
-    require __DIR__ . '/../TaxJarTest.php';
-}
+
+namespace TaxJar\Tests\specs;
+
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use TaxJar\Tests\TaxJarTest;
 
 class ValidationTest extends TaxJarTest
 {
     public function testValidateAddress()
     {
-        $this->http->mock
-            ->when()
-            ->methodIs('POST')
-            ->pathIs('/addresses/validate')
-            ->then()
-            ->statusCode(200)
-            ->body(file_get_contents(__DIR__ . "/../fixtures/addresses.json"))
-            ->end();
-
-        $this->http->setUp();
+        $this->http->append(new Response(200, [], file_get_contents(__DIR__ . "/../fixtures/addresses.json")));
 
         $response = $this->client->validateAddress([
             'country' => 'US',
@@ -26,6 +20,13 @@ class ValidationTest extends TaxJarTest
             'street' => '3301 South Greenfield Rd'
         ]);
 
+        $this->assertCount(1, $this->history);
+
+        /** @var Request $request */
+        $request = reset($this->history)['request'];
+        $this->assertSame('POST', $request->getMethod());
+        $this->assertSame('/addresses/validate', $request->getUri()->getPath());
+
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/addresses.json', json_encode([
             "addresses" => $response
         ]));
@@ -33,23 +34,19 @@ class ValidationTest extends TaxJarTest
 
     public function testValidation()
     {
-        $queryString = version_compare(PHP_VERSION, '7.1.0', '<') ? '?vat=FR40303265045' : '';
-
-        $this->http->mock
-            ->when()
-            ->methodIs('GET')
-            ->pathIs('/validation' . $queryString)
-            ->queryParamIs('vat', 'FR40303265045')
-            ->then()
-            ->statusCode(200)
-            ->body(file_get_contents(__DIR__ . "/../fixtures/validation.json"))
-            ->end();
-
-        $this->http->setUp();
+        $this->http->append(new Response(200, [], file_get_contents(__DIR__ . "/../fixtures/validation.json")));
 
         $response = $this->client->validate([
             'vat' => 'FR40303265045',
         ]);
+
+        $this->assertCount(1, $this->history);
+
+        /** @var Request $request */
+        $request = reset($this->history)['request'];
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('/validation', $request->getUri()->getPath());
+        $this->assertSame('vat=FR40303265045', $request->getUri()->getQuery());
 
         $this->assertJsonStringEqualsJsonFile(__DIR__ . '/../fixtures/validation.json', json_encode([
             "validation" => $response


### PR DESCRIPTION
In order to have PHP 8 support, I had to remove `internations/http-mock` since it and its dependencies do not support PHP 8 and will require serious refactoring to do so.  

So, instead of relying on mostly unmaintained packages, making use of what Guzzle provides out-of-the-box for testing and mocking. And updating to the latest PHPUnit to have support for PHP 8 also means that will have to drop PHP 5.* support.

Overall, there are no breaking changes but the minimal PHP version is raised to 7.2.