### PR TITLE
Fix error handler for array-type detail fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.0.1] - 2025-05-08
+- Handle error detail as array
+
 ## [2.0.0] - 2022-09-30
 - Adds PHP 8.x support and drops support for PHP <= 7.x
 
@@ -112,7 +115,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Initial release.
 
-[Unreleased]: https://github.com/taxjar/taxjar-php/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/taxjar/taxjar-php/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/taxjar/taxjar-php/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/taxjar/taxjar-php/compare/v1.10.4...v2.0.0
 [1.10.4]: https://github.com/taxjar/taxjar-php/compare/v1.10.3...v1.10.4
 [1.10.3]: https://github.com/taxjar/taxjar-php/compare/v1.10.2...v1.10.3

--- a/lib/TaxJar.php
+++ b/lib/TaxJar.php
@@ -3,7 +3,7 @@ namespace TaxJar;
 
 class TaxJar
 {
-    const VERSION = '2.0.0';
+    const VERSION = '2.0.1';
     const DEFAULT_API_URL = 'https://api.taxjar.com';
     const SANDBOX_API_URL = 'https://api.sandbox.taxjar.com';
     const API_VERSION = 'v2';
@@ -36,12 +36,22 @@ class TaxJar
             if ($response->getStatusCode() >= 400) {
                 $data = json_decode($response->getBody());
 
+                // Handle detail field which can be string or array
+                $detail = 'please try again';
+                if (isset($data->detail)) {
+                    if (is_array($data->detail)) {
+                        $detail = implode('; ', $data->detail);
+                    } else {
+                        $detail = $data->detail;
+                    }
+                }
+
                 throw new Exception(
                     sprintf(
                         '%s %s – %s',
                         $response->getStatusCode(),
                         isset($data->error) ? $data->error : 'something unexpected occurred',
-                        isset($data->detail) ? $data->detail : 'please try again'
+                        $detail
                     ),
                     $response->getStatusCode()
                 );

--- a/test/specs/ErrorHandlingTest.php
+++ b/test/specs/ErrorHandlingTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace TaxJar\Tests\specs;
+
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use TaxJar\Exception;
+use TaxJar\Tests\TaxJarTest;
+
+class ErrorHandlingTest extends TaxJarTest
+{
+    public function setUp(): void
+    {
+        // Create the mock handler first
+        $this->http = new MockHandler();
+        
+        // Create a handler stack with the mock handler
+        $handler = HandlerStack::create($this->http);
+        
+        // Add history middleware
+        $handler->push(Middleware::history($this->history));
+        
+        // Create the client (which will set up its own error handling middleware)
+        $this->client = new \TaxJar\Client('test');
+        
+        // Get the client's handler stack (which includes error handling)
+        $clientHandler = $this->client->getApiConfig('handler');
+        
+        // Push our mock handler onto the client's stack
+        $clientHandler->setHandler($this->http);
+        
+        // Set the base URI for testing
+        $this->client->setApiConfig('base_uri', 'http://localhost:8082');
+    }
+
+    public function testStringErrorDetail()
+    {
+        try {
+            $this->http->append(new Response(400, [], json_encode([
+                'status' => '400',
+                'error' => 'Bad Request',
+                'detail' => 'Invalid request parameters'
+            ])));
+
+            $this->client->categories();
+            $this->fail('Expected an exception to be thrown');
+        } catch (Exception $e) {
+            $this->assertEquals('400 Bad Request – Invalid request parameters', $e->getMessage());
+            $this->assertEquals(400, $e->getStatusCode());
+        }
+    }
+
+    public function testArrayErrorDetail()
+    {
+        try {
+            $this->http->append(new Response(406, [], json_encode([
+                'status' => '406',
+                'error' => 'Not Acceptable',
+                'detail' => [
+                    'state must be a two-letter ISO code.',
+                    'zip must be a valid postal code.'
+                ]
+            ])));
+
+            $this->client->categories();
+            $this->fail('Expected an exception to be thrown');
+        } catch (Exception $e) {
+            $this->assertEquals('406 Not Acceptable – state must be a two-letter ISO code.; zip must be a valid postal code.', $e->getMessage());
+            $this->assertEquals(406, $e->getStatusCode());
+        }
+    }
+
+    public function testMissingErrorDetail()
+    {
+        try {
+            $this->http->append(new Response(500, [], json_encode([
+                'status' => '500',
+                'error' => 'Internal Server Error'
+            ])));
+
+            $this->client->categories();
+            $this->fail('Expected an exception to be thrown');
+        } catch (Exception $e) {
+            $this->assertEquals('500 Internal Server Error – please try again', $e->getMessage());
+            $this->assertEquals(500, $e->getStatusCode());
+        }
+    }
+} 


### PR DESCRIPTION
Resolves https://github.com/taxjar/taxjar-php/issues/53

This work handles error detail as a string or an array. I've added a spec to go with the changes.